### PR TITLE
Removed checking dispatchContent method

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -14,7 +14,7 @@ if (!function_exists("tracy_wrap")) {
 
         if ($debugMode) {
             $bar = Debugger::getBar();
-            if ($bar->dispatchAssets() || $bar->dispatchContent()) {
+            if ($bar->dispatchAssets()) {
                 if (func_num_args() === 3) {
                     return /* for unit testing only */;
                 }


### PR DESCRIPTION
Because of got an error "Call to undefined method Tracy\Bar::dispatchContent()" - with Tracy 2.7.2